### PR TITLE
Add criterion microbenchmarks and optimize sexp_no_leading_blank.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = "0.2"
 rsexp-derive = { version = "0.2.2", path = "rsexp-derive" }
 criterion = "0.3"
 rand = "0.8.4"
+rand_pcg = "0.3.1"
 
 [[bench]]
 name = "rsexp_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,12 @@ clap = "3.0.0-beta.5"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 rsexp-derive = { version = "0.2.2", path = "rsexp-derive" }
+criterion = "0.3"
+rand = "0.8.4"
+
+[[bench]]
+name = "rsexp_benchmark"
+harness = false
+
+[profile.bench]
+debug=true

--- a/benches/rsexp_benchmark.rs
+++ b/benches/rsexp_benchmark.rs
@@ -1,0 +1,67 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+fn make_n_random_characters(n: i64, alphabet: &Vec<char>) -> String {
+    let mut rng = thread_rng();
+    (0..n).map(|_| alphabet.choose(&mut rng).unwrap()).collect()
+}
+
+fn make_benchmark_string(
+    num_repetitions: &[i64],
+    str_len: i64,
+    quoted: bool,
+    alphabet: &Vec<char>,
+) -> String {
+    if let Some(len) = num_repetitions.get(0) {
+        format!(
+            "({})",
+            std::iter::repeat(make_benchmark_string(
+                &num_repetitions[1..],
+                str_len,
+                quoted,
+                alphabet
+            ))
+            .take(*len as usize)
+            .collect::<String>()
+        )
+    } else {
+        let chars = make_n_random_characters(str_len, alphabet);
+        if quoted {
+            format!("\"{}\"", chars)
+        } else {
+            chars
+        }
+    }
+}
+
+fn parse_sexp(contents: &[u8]) {
+    let _sexp = rsexp::from_slice(&contents).unwrap();
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let alphabet: Vec<char> = (b'a'..=b'z').map(char::from).collect();
+
+    for quoted in [true, false] {
+        for (str_len, repetitions, depth) in
+            [(4, 100, 1), (4, 100, 2), (10, 100, 2), (1000, 100, 1)]
+        {
+            let bench_name = format!(
+                "{repetitions}_repetitions_{depth}_depth_{str_len}_strlen_{quoted}",
+                repetitions = repetitions,
+                depth = depth,
+                str_len = str_len,
+                quoted = (if quoted { "quoted" } else { "unquoted" })
+            );
+            let num_repetitions: Vec<i64> =
+                std::iter::repeat(repetitions as i64).take(depth).collect();
+            let sexp = make_benchmark_string(&num_repetitions, str_len, quoted, &alphabet);
+            c.bench_function(&bench_name, |b| {
+                b.iter(|| parse_sexp(black_box(sexp.as_bytes())))
+            });
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,6 @@
 // TODO: Block comments.
 use nom::{
+    branch::alt,
     character::complete::char,
     error::{Error, ErrorKind, ParseError},
     multi::many0,
@@ -188,12 +189,11 @@ fn quoted_string(input: &[u8]) -> Res<&[u8], Vec<u8>> {
 }
 
 fn atom(input: &[u8]) -> Res<&[u8], Sexp> {
-    if !input.is_empty() && input[0] == b'"' {
-        delimited(char('"'), quoted_string, char('"'))(input)
-            .map(|(next_input, atom)| (next_input, Sexp::Atom(atom)))
-    } else {
-        unquoted_string(input).map(|(next_input, atom)| (next_input, Sexp::Atom(atom)))
-    }
+    alt((
+        unquoted_string,
+        delimited(char('"'), quoted_string, char('"')),
+    ))(input)
+    .map(|(next_input, atom)| (next_input, Sexp::Atom(atom)))
 }
 
 fn sexp_in_list(input: &[u8]) -> Res<&[u8], Sexp> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,7 @@
 // TODO: Block comments.
 use nom::{
-    branch::alt,
     character::complete::char,
-    error::{context, Error, ErrorKind, ParseError},
+    error::{Error, ErrorKind, ParseError},
     multi::many0,
     sequence::{delimited, pair, preceded, terminated},
     IResult, InputTake,
@@ -189,24 +188,19 @@ fn quoted_string(input: &[u8]) -> Res<&[u8], Vec<u8>> {
 }
 
 fn atom(input: &[u8]) -> Res<&[u8], Sexp> {
-    context(
-        "atom",
-        alt((
-            unquoted_string,
-            delimited(char('"'), quoted_string, char('"')),
-        )),
-    )(input)
-    .map(|(next_input, atom)| (next_input, Sexp::Atom(atom)))
+    if !input.is_empty() && input[0] == b'"' {
+        delimited(char('"'), quoted_string, char('"'))(input)
+            .map(|(next_input, atom)| (next_input, Sexp::Atom(atom)))
+    } else {
+        unquoted_string(input).map(|(next_input, atom)| (next_input, Sexp::Atom(atom)))
+    }
 }
 
 fn sexp_in_list(input: &[u8]) -> Res<&[u8], Sexp> {
-    context(
-        "sexp-in-list",
-        delimited(
-            pair(char('('), space_or_comments),
-            many0(sexp_no_leading_blank),
-            char(')'),
-        ),
+    delimited(
+        pair(char('('), space_or_comments),
+        many0(sexp_no_leading_blank),
+        char(')'),
     )(input)
     .map(|(next_input, res)| (next_input, Sexp::List(res)))
 }
@@ -215,7 +209,11 @@ fn sexp_in_list(input: &[u8]) -> Res<&[u8], Sexp> {
 // separated_list combinator does not seem to handle separators that
 // can be empty.
 fn sexp_no_leading_blank(input: &[u8]) -> Res<&[u8], Sexp> {
-    terminated(alt((atom, sexp_in_list)), space_or_comments)(input)
+    if !input.is_empty() && input[0] == b'(' {
+        terminated(sexp_in_list, space_or_comments)(input)
+    } else {
+        terminated(atom, space_or_comments)(input)
+    }
 }
 
 /// Deserialize a Sexp from bytes, returning both the sexp and the remaining


### PR DESCRIPTION
This PR adds some microbenchmarks which generate different example sexps of different lengths, depths, number of characters per atom, and quoted/unquoted atoms.

These benchmarks were then used to optimize `sexp_no_leading_blank`. The main two changes are:

- remove `context()` calls, saving a few % across the board.
- replace `nom::branch::alt` in `sexp_no_leading_blank` with a rust-native if-condition.

The same optimization turns out not to improve things much in `atom`.

See [report](http://137.184.201.68:8000/report/) for details (tested on `Intel Xeon Processor (Cascadelake), 2693 MHz` via digitalocean). Also tested on `Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz` with similar results.

Use this command to save a baseline (default name is `base`):
```bash
cargo bench --bench rsexp_benchmark -- --save-baseline
```
And this command to run comparing against a saved baseline:
```bash
cargo bench --bench rsexp_benchmark --  --baseline base
```