### PR TITLE
fix OfSexp derive macro for enum variants without a tuple or struct parameter

### DIFF
--- a/rsexp-derive/src/lib.rs
+++ b/rsexp-derive/src/lib.rs
@@ -218,7 +218,9 @@ fn impl_of_sexp(ast: &DeriveInput) -> TokenStream {
                     syn::Fields::Unnamed(f) => {
                         impl_unnamed_struct_of_sexp(f, quote! {#ident::#variant_ident})
                     }
-                    syn::Fields::Unit => quote! {#ident::#variant_ident},
+                    syn::Fields::Unit => {
+                        quote! {::core::result::Result::Ok(#ident::#variant_ident)}
+                    }
                 };
                 quote! {
                     (#variant_bytes, __fields) => {

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -198,7 +198,8 @@ struct StructXY {
 
 #[derive(SexpOf, Debug, PartialEq)]
 enum MyEnum {
-    A(),
+    A,
+    AEmptyTuple(),
     AEmptyStruct {},
     B(()),
     C(i64),
@@ -211,7 +212,8 @@ enum MyEnum {
 
 #[test]
 fn my_enum() {
-    test_bytes(MyEnum::A(), "A");
+    test_bytes(MyEnum::A, "A");
+    test_bytes(MyEnum::AEmptyTuple(), "AEmptyTuple");
     test_bytes(MyEnum::AEmptyStruct {}, "AEmptyStruct");
     test_bytes(MyEnum::B(()), "(B ())");
     test_bytes(MyEnum::C(42), "(C 42)");
@@ -231,7 +233,8 @@ struct StructXYZ {
 
 #[derive(OfSexp, SexpOf, Debug, PartialEq, Eq)]
 enum MyEnum2 {
-    A(),
+    A,
+    AEmptyTuple(),
     AEmptyStruct {},
     B(()),
     C(i64),
@@ -243,7 +246,8 @@ enum MyEnum2 {
 
 #[test]
 fn my_enum2() {
-    test_rt(MyEnum2::A(), "A");
+    test_rt(MyEnum2::A, "A");
+    test_rt(MyEnum2::AEmptyTuple(), "AEmptyTuple");
     test_rt(MyEnum2::AEmptyStruct {}, "AEmptyStruct");
     test_rt(MyEnum2::B(()), "(B ())");
     test_rt(MyEnum2::C(42), "(C 42)");


### PR DESCRIPTION
@LaurentMazare It seems the `OfSexp` derive macro is currently broken for enum constructors with no parameters (i.e., a constructor that doesn't take a tuple or struct argument).  For these constructors, the `OfSexp` derive macro should generate code to return `Ok(Type::Constructor)` but instead generates code to return just `Type::Constructor`.